### PR TITLE
fix(testing): switch emitDecoratorMetadata to false

### DIFF
--- a/apps/my-app/src/app/tests/test-app.spec.ts
+++ b/apps/my-app/src/app/tests/test-app.spec.ts
@@ -21,4 +21,7 @@ describe('Data State', () => {
 
     store = TestBed.inject(Store);
   });
+  it('should create', () => {
+    expect(store).toBeTruthy();
+  });
 });

--- a/apps/my-app/tsconfig.spec.json
+++ b/apps/my-app/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "emitDecoratorMetadata": false
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.js", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main",
     "start": "nx serve",
     "build": "nx build",
-    "test": "nx test"
+    "test": "yarn jest --clear-cache && nx test my-app --skip-nx-cache"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
ref: https://github.com/nrwl/nx/issues/10660#issuecomment-1250692680

issue worth noting: https://github.com/ngxs/store/issues/1720

should be fine unless you need reflection at test time.

```
yarn test
yarn run v1.22.15
$ yarn jest --clear-cache && nx test my-app --skip-nx-cache
$ /Users/caleb/Work/jcabannes/nx-angular-ngxs-jest/node_modules/.bin/jest --clear-cache
Cleared /private/var/folders/ws/_4mjt9x975g1z4r61kwm6c8r0000gn/T/jest_dx
Cleared /private/var/folders/ws/_4mjt9x975g1z4r61kwm6c8r0000gn/T/jest_dx

> nx run my-app:test

Determining test suites to run...
ngcc-jest-processor: running ngcc
 PASS   my-app  apps/my-app/src/app/tests/test-app.spec.ts
  Data State
    ✓ should create (44 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.811 s
Ran all test suites.

 —————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target test for project my-app (3s)

✨  Done in 3.99s.
```
